### PR TITLE
Expose the jwt invalidate method

### DIFF
--- a/src/Contracts/AuthJWTInterface.php
+++ b/src/Contracts/AuthJWTInterface.php
@@ -61,4 +61,12 @@ interface AuthJWTInterface
      * @return [bool]
      */
     public function verifyToken(string $token, callable $callback = null): bool;
+
+    /**
+     * Invalidate a token.
+     * @param  string $token The user token
+     * @param  bool   $isRefresh True if the token is a refresh token
+     * @return bool
+     */
+    public function invalidate(string $token, bool $isRefresh = false): bool;
 }

--- a/src/Services/AuthJWTService.php
+++ b/src/Services/AuthJWTService.php
@@ -302,7 +302,8 @@ class AuthJWTService implements Contracts\AuthJWTInterface
      * @param  bool   $isRefresh True if the token is a refresh token
      * @return bool
      */
-    public function invalidate(string $token, bool $isRefresh = false): bool {
+    public function invalidate(string $token, bool $isRefresh = false): bool
+    {
         if (empty($token)) {
             return true;
         }

--- a/src/Services/AuthJWTService.php
+++ b/src/Services/AuthJWTService.php
@@ -297,6 +297,20 @@ class AuthJWTService implements Contracts\AuthJWTInterface
     }
 
     /**
+     * Invalidate a token.
+     * @param  string $token The user token
+     * @param  bool   $isRefresh True if the token is a refresh token
+     * @return bool
+     */
+    public function invalidate(string $token, bool $isRefresh = false): bool {
+        if (empty($token)) {
+            return true;
+        }
+
+        return $this->jwt->invalidate($token, $isRefresh);
+    }
+
+    /**
      * Get a validator for an incoming login request.
      *
      * @param array $data


### PR DESCRIPTION
### Working Issue
- Expose the jwt invalidate method.

Project that use SunAuth can manually invalidate a token by calling the exposed method. This can be helpful for feature like `only allow one login session at a moment`
```
$this->sunAuthService->invalidate($previousAccessToken);
$this->sunAuthService->invalidate($previousRefreshToken, true);
```

### What i did
- [x] Add the invalidate method to the jwt service to expose the SunJwt invalidate method


### [Checklist](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-1-pull-request-has-been-self-reviewed)
- [x] Pull request has been self-reviewed
- [x] Check impacted areas

### [UnitTest](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-6-self-describing-test-method)
- [ ] Self-describing test method
- [ ] My tests are fast!

### [Security](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-12-validate-all-data-sent-from-the-client)
- [ ] Validate all data sent from the client
- [ ] Output has no information about SQL query

### [Performance](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-16-resolved-n--1-query)
- [ ] Resolved n + 1 query
- [ ] Time open page < 1000 ms
