### PR TITLE
Fix bug check key config auth generate exists in info users table

### DIFF
--- a/src/Services/AuthJWTService.php
+++ b/src/Services/AuthJWTService.php
@@ -75,9 +75,9 @@ class AuthJWTService implements Contracts\AuthJWTInterface
 
         $tokenPayload = [];
         foreach ($this->tokenPayloadFields() as $tokenPayloadField) {
-            if (!$itemArr[$tokenPayloadField]) {
+            if (!array_key_exists($tokenPayloadField, $itemArr)) {
                 throw ValidationException::withMessages([
-                    'message' => $this->getFailedLoginMessage(),
+                    'message' => $this->getInvalidConfigurationMessage(),
                 ]);
             }
             $tokenPayload[$tokenPayloadField] = $itemArr[$tokenPayloadField];
@@ -394,5 +394,15 @@ class AuthJWTService implements Contracts\AuthJWTInterface
         return Lang::has('validation.email')
             ? Lang::get('validation.email', ['attribute' => $email])
             : 'The email is invalid.';
+    }
+
+    /**
+     * @return string|\Symfony\Component\Translation\TranslatorInterface
+     */
+    protected function getInvalidConfigurationMessage(): string
+    {
+        return Lang::has('auth.invalid_configuration')
+            ? Lang::get('auth.invalid_configuration')
+            : 'Invalid auth configuration';
     }
 }


### PR DESCRIPTION
### Working Issue
- When the value get from the user table is null, an error occurs because the function is checking the value and should be checking whether the key exists or not and an error is reported.

### What i did
- Change function check key config exists in array info users table


### [Checklist](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-1-pull-request-has-been-self-reviewed)
- [x] Pull request has been self-reviewed
- [x] Check impacted areas

### [UnitTest](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-6-self-describing-test-method)
- [x] Self-describing test method
- [x] My tests are fast!

### [Security](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-12-validate-all-data-sent-from-the-client)
- [x] Validate all data sent from the client
- [x] Output has no information about SQL query

### [Performance](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-16-resolved-n--1-query)
- [x] Resolved n + 1 query
- [x] Time open page < 1000 ms
