### PR TITLE
Blacklisted access_token and refresh_token separately

### DIFF
--- a/src/SunBlacklist.php
+++ b/src/SunBlacklist.php
@@ -35,15 +35,16 @@ class SunBlacklist
 
         // if expired less than now
         $valid = $payload['exp'];
-        $seconds = Carbon::now()->diffInSeconds(Carbon::createFromTimestamp($valid));
-        if ($seconds < 0) {
+        $now = Carbon::now();
+        if ($valid <= $now->timestamp) {
             return true;
         }
 
+        $diffInSeconds = $now->diffInSeconds(Carbon::createFromTimestamp($valid));
         $this->storage->add(
             $key,
             ['valid_until' => $valid],
-            $seconds,
+            $diffInSeconds,
         );
 
         return true;

--- a/src/SunJWT.php
+++ b/src/SunJWT.php
@@ -122,14 +122,12 @@ class SunJWT
 
     public function make(array $sub, $isRefresh = false): self
     {
-        if (empty($this->payload)) {
-            $now = Carbon::now();
-            $this->payload = [
-                'sub' => $sub,
-                'iat' => $now->timestamp,
-                'jti' => Str::random(6) . $now->timestamp,
-            ];
-        }
+        $now = Carbon::now();
+        $this->payload = [
+            'sub' => $sub,
+            'iat' => $now->timestamp,
+            'jti' => Str::random(6) . $now->getTimestampMs(),
+        ];
 
         $iat = $this->payload['iat'];
         $ttl = $isRefresh ? $this->rttl : $this->ttl;


### PR DESCRIPTION
### Working Issue
Issue: #ID

### What i did
- Blacklisted access_token and refresh_token separately
- Change logic generate `JTI` from timestamp to timestampMs
- Change logic check token expired


### [Checklist](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-1-pull-request-has-been-self-reviewed)
- [x] Pull request has been self-reviewed
- [x] Check impacted areas

### [UnitTest](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-6-self-describing-test-method)
- [ ] Self-describing test method
- [ ] My tests are fast!

### [Security](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-12-validate-all-data-sent-from-the-client)
- [ ] Validate all data sent from the client
- [ ] Output has no information about SQL query

### [Performance](https://github.com/the-cev7/checklist-code-review#heavy_check_mark-16-resolved-n--1-query)
- [ ] Resolved n + 1 query
- [ ] Time open page < 1000 ms
